### PR TITLE
add map pin for generic esp32

### DIFF
--- a/OpenFIREshared.h
+++ b/OpenFIREshared.h
@@ -515,8 +515,17 @@ public:
                                  /*45*/ pinI2C0SCL | pinSPI1CSn | pinHasADC,        pinI2C1SDA | pinSPI1SCK | pinHasADC,    pinI2C1SCL | pinSPI1TX  | pinHasADC                                                                                      }},
         //====================================================
         // Base Microcontroller: ESP32
-        // *To be filled out by someone that knows how this board works
-
+        // esp32s3 has two ADC, ADC1 (10 channels (GPIO1 – GPIO10)) e ADC2 (10 channels (GPIO11 – GPIO20)). ADC2 has some handicaps because it is also used by the Wi-Fi module
+        {boardArchs[boardESP32],{/*00*/ pinDigital,                                 pinHasADC | pinI2C0SDA | pinI2C1SDA,    pinHasADC | pinI2C0SCL | pinI2C1SCL,    pinHasADC,                              pinHasADC | pinI2C0SDA | pinI2C1SDA,
+                                 /*05*/ pinHasADC | pinI2C0SCL | pinI2C1SCL,        pinHasADC,                              pinHasADC,                              pinHasADC | pinI2C0SDA | pinI2C1SDA,    pinHasADC | pinI2C0SCL | pinI2C1SCL,
+                                 /*10*/ pinHasADC | pinSPI0CSn | pinSPI1CSn,        pinSPI0TX | pinSPI1TX,                  pinSPI0SCK | pinSPI1SCK,                pinSPI0RX | pinSPI1RX,                  pinDigital,
+                                 /*15*/ pinI2C0SCL | pinI2C1SCL,                    pinDigital,                             pinDigital,                             pinI2C0SDA | pinI2C1SDA,                pinDigital,
+                                 /*20*/ pinDigital,                                 pinDigital,                             pinDigital,                             pinDigital,                             pinDigital,
+                                 /*25*/ pinDigital,                                 pinDigital,                             pinDigital,                             pinDigital,                             pinDigital,
+                                 /*30*/ pinDigital,                                 pinDigital,                             pinDigital,                             pinDigital,                             pinDigital,
+                                 /*35*/ pinI2C0SDA | pinI2C1SDA,                    pinI2C0SCL | pinI2C1SCL,                pinDigital,                             pinDigital,                             pinDigital,
+                                 /*40*/ pinDigital,                                 pinDigital,                             pinDigital,                             pinDigital,                             pinDigital,
+                                 /*45*/ pinDigital,                                 pinDigital,                             pinDigital,                             pinDigital,                             pinDigital                              }},
         //====================================================
         // Board Overrides: Raspberry Pi Pico (Non-/W)
         // Some pins that should have I2C or SPI functions apparently aren't allowed on rpipico(w)?


### PR DESCRIPTION
I added a generic pin map for esp32, certainly working. I inserted a generic configuration of the most used ones, but the esp32 is much more versatile and practically any pin can be configured for I2C SDA or I2C SCL (for both two channels), as well as the SPI lines (for both two channels). Practically every PIN of the micro can be configured for almost anything. Eight bits to manage all the possible configurations are not enough, it would take one bit for each possibility (example: gpio1 can be used for both I2C0SDA, I2C0SCL, I2C1SDA, I2C1SCL, SPI0RX, SPI0TX ..... SPI1CSn). However, there are no problems, you can also leave it as you have set it, we limit the choices by the pin map settings in Board.