### PR TITLE
Added common temperature sensor error value.

### DIFF
--- a/OpenFIREshared.h
+++ b/OpenFIREshared.h
@@ -471,6 +471,8 @@ public:
         /* more ESP boards should be added here */
     };
 
+    static const unsigned int TEMPERATURE_SENSOR_ERROR_VALUE = 125; // ADC reading indicating sensor fault / disconnection.
+
 // Only needed for the Desktop App, don't build for microcontroller firmware!
 #ifdef OF_APP
 


### PR DESCRIPTION
This pull request adds a new constant to the `OF_Const` class in `OpenFIREshared.h` to represent a specific error value for temperature sensor faults or disconnections.

Sensor error handling:

* Added `TEMPERATURE_SENSOR_ERROR_VALUE` constant to `OF_Const` to indicate an ADC reading that signals a temperature sensor fault or disconnection.

**ATTENTION**:
This PR is required for other PRs in firmware and app repo:
https://github.com/TeamOpenFIRE/OpenFIRE-Firmware/pull/141
https://github.com/TeamOpenFIRE/OpenFIRE-App/pull/109